### PR TITLE
fix(stdlib): don't force newline after printf

### DIFF
--- a/c.php
+++ b/c.php
@@ -295,7 +295,7 @@ if (!$func) exit(69);
 foreach($func->body as &$stmt) {
     if ($stmt instanceof FuncallStmt) {
         if ($stmt->name->value === "printf") {
-            echo sprintf("print(\"%s\")\n", join(", ", $stmt->args));
+            echo sprintf("print(\"%s\", end=\"\")\n", join(", ", $stmt->args));
         } else {
             echo sprintf("%s: ERROR: unknown function %s\n", 
                 $stmt->name->loc->display(),

--- a/hello.c
+++ b/hello.c
@@ -2,7 +2,7 @@
 
 int main()
 {
-    printf("Hello, World");
-    printf("Foo, Bar");
+    printf("Hello, World\n");
+    printf("Foo, Bar\n");
     return 0;
 }


### PR DESCRIPTION
C's printf does not add newlines, but c.php's standard printf function does. Change c.php to match the C standard behavior.