### PR TITLE
feat(backend): optimize printf("literal\n");

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# C to Python compiler in PHP
+# Optimizing C to Python compiler in PHP
 
 This is an April Fools joke. Please don't take it seriously. It only supports a very small subset of C. Literally return and function call. We even made printf an intrinsic. Please don't use it in production.
 

--- a/c.php
+++ b/c.php
@@ -321,9 +321,9 @@ foreach($func->body as &$stmt) {
     if ($stmt instanceof FuncallStmt) {
         if ($stmt->name->value === "printf") {
             $format = $stmt->args[0];
-            $substitutions = "";
             if (count($stmt->args) <= 1) {
                 // Optimization: Don't invoke Python's % operator if it's unnecessary.
+                echo sprintf("print(%s, end=\"\")\n", literal_to_py($format));
             } else {
                 $substitutions = " % (";
                 foreach ($stmt->args as $i => $arg) {
@@ -331,8 +331,8 @@ foreach($func->body as &$stmt) {
                     $substitutions .= literal_to_py($arg) . ",";
                 }
                 $substitutions .= ")";
+                echo sprintf("print(%s%s, end=\"\")\n", literal_to_py($format), $substitutions);
             }
-            echo sprintf("print(%s%s, end=\"\")\n", literal_to_py($format), $substitutions);
         } else {
             echo sprintf("%s: ERROR: unknown function %s\n", 
                 $stmt->name->loc->display(),

--- a/hello.c
+++ b/hello.c
@@ -3,6 +3,7 @@
 int main()
 {
     printf("Hello, World\n");
+    printf("important: ");
     printf("Foo, %s, %d\n", "Bar", 69);
     return 0;
 }


### PR DESCRIPTION
C printf("foo\n"); is currently lowered Python print("foo\n", end="").
This is slower than print("foo"), which is what a human would write:

    $ python3 -m timeit 'print("x\n", end="")' | tail -n1
    2000000 loops, best of 5: 184 nsec per loop

    $ python3 -m timeit 'print("x")' | tail -n1
    2000000 loops, best of 5: 164 nsec per loop

Where possible, compile printf to print without end=.
